### PR TITLE
[FIX] Date can be empty and call to onchange_partner_id function

### DIFF
--- a/account_periodical_invoicing/models/periodical_invoicing.py
+++ b/account_periodical_invoicing/models/periodical_invoicing.py
@@ -80,6 +80,8 @@ class Agreement(models.Model):
         get max date
         """
         for agreement in self:
+            if not agreement.start_date:
+                agreement.start_date = fields.Date.today()
             if agreement.prolong == 'fixed':
                 agreement.next_expiration_date = agreement.end_date
             elif agreement.prolong == 'unlimited':
@@ -97,8 +99,8 @@ class Agreement(models.Model):
             else:
                 # for renewable fixed term
                 agreement.next_expiration_date = self._get_next_term_date(
-                    fields.Date.to_string(agreement.last_renovation_date or
-                                          agreement.start_date),
+                    fields.Date.from_string(agreement.last_renovation_date or
+                                            agreement.start_date),
                     agreement.prolong_unit, agreement.prolong_interval)
 
     def _get_default_currency_id(self):

--- a/account_periodical_invoicing/models/periodical_invoicing.py
+++ b/account_periodical_invoicing/models/periodical_invoicing.py
@@ -41,6 +41,8 @@ class Agreement(models.Model):
         @rtype: date
         @return: The date incremented in 'interval' units of 'unit'.
         """
+        if not date or not unit or not interval:
+            return False
         if unit == 'days':
             return date + timedelta(days=interval)
         elif unit == 'weeks':
@@ -59,6 +61,8 @@ class Agreement(models.Model):
         @rtype: date
         @return: The date decremented in 'interval' units of 'unit'.
         """
+        if not date or not unit or not interval:
+            return False
         if unit == 'days':
             return date - timedelta(days=interval)
         elif unit == 'weeks':
@@ -83,6 +87,8 @@ class Agreement(models.Model):
                 date = self._get_next_term_date(
                     fields.Date.from_string(agreement.start_date),
                     agreement.prolong_unit, agreement.prolong_interval)
+                if not date:
+                    continue
                 while date < today:
                     date = self._get_next_term_date(
                         date, agreement.prolong_unit,
@@ -340,7 +346,7 @@ class Agreement(models.Model):
             company_id=agreement.company_id.id,
             force_company=agreement.company_id.id)
         onchange_vals = obj.onchange_partner_id(
-            type=invoice_vals['type'], partner_id=agreement.partner_id.id,
+            invoice_vals['type'], agreement.partner_id.id,
             company_id=agreement.company_id.id)
         invoice_vals.update(onchange_vals['value'])
         return invoice_vals


### PR DESCRIPTION
Probando el módulo hemos detectado un par de errores:

1. Al ir a Crear un contrato desde la interfaz, saltaba un error porque el campo `Date` no estaba relleno.
2. Al ejecutarse el cron daba error en la llamada a `onchange_partner_id`

De momento, con este par de modificaciones parece que funciona correctamente. Seguiremos haciendo pruebas.

Gracias!